### PR TITLE
fix: incorrect svg calculation on firefox & safari

### DIFF
--- a/src/cursor-trigger.module.css
+++ b/src/cursor-trigger.module.css
@@ -11,6 +11,7 @@
 }
 
 .hover-trigger-container {
+  display: block;
   position: relative;
 }
 


### PR DESCRIPTION
We used to have `divs` which are already displaying block by nature, but since we replaced it with `spans` this messed up the calculation of the SVG in Firefox & Safari. Setting the container to display block fixes this issue.